### PR TITLE
update service file to extract dotnet single file executables into th…

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -157,7 +157,7 @@ Description=Enclave
 After=network.target
 
 [Service]
-Environment="DOTNET_BUNDLE_EXTRACT_BASE_DIR=%h/.net/"
+Environment="DOTNET_BUNDLE_EXTRACT_BASE_DIR=%h/.net/enclave"
 ExecStart=/usr/bin/enclave supervisor-service
 
 [Install]

--- a/setup.sh
+++ b/setup.sh
@@ -157,7 +157,7 @@ Description=Enclave
 After=network.target
 
 [Service]
-Environment="DOTNET_BUNDLE_EXTRACT_BASE_DIR=/var/tmp/.net/"
+Environment="DOTNET_BUNDLE_EXTRACT_BASE_DIR=%h/.net/"
 ExecStart=/usr/bin/enclave supervisor-service
 
 [Install]


### PR DESCRIPTION
…e users home directory

extracting to /var/tmp, writable by any user opens up a timing attack whereby the .net self extract process can be intercepted and potentially abused for privilege escalation. forcing binaries to extract to the users home directory limits the exposure