### PR TITLE
Add unattended powershell setup script

### DIFF
--- a/setup-unattended.ps1
+++ b/setup-unattended.ps1
@@ -21,8 +21,10 @@ $newEnclaveVersion = "$($latestGaRelease.MajorVersion).$($latestGaRelease.MinorV
 
 $ErrorActionPreference = 'SilentlyContinue';
 
-$enclaveBinaryPath = "C:\Program Files\Enclave Networks\Enclave\Agent\bin\enclave.exe";
-$enclaveTrayPath = "C:\Program Files\Enclave Networks\Enclave\Agent\bin\enclave-tray.exe";
+$programFiles = [Environment]::GetFolderPath([Environment+SpecialFolder]::ProgramFiles);
+
+$enclaveBinaryPath = "$programFiles\Enclave Networks\Enclave\Agent\bin\enclave.exe";
+$enclaveTrayPath = "$programFiles\Enclave Networks\Enclave\Agent\bin\enclave-tray.exe";
 
 $existingEnclaveVersion = $(get-command $enclaveBinaryPath);
 
@@ -65,7 +67,7 @@ if ($newEnclaveVersion -ne $existingEnclaveVersion)
 
     if (!$existingEnclaveVersion)
     {
-        "Installing VC++ Redistributable if needed";
+        "Installing VC++ Redistributable";
 
         $vcRedistInstallPath = Join-Path $env:TEMP "enclave_vcredist.exe";
     
@@ -75,7 +77,7 @@ if ($newEnclaveVersion -ne $existingEnclaveVersion)
         & $vcRedistInstallPath "/install" "/silent" "/norestart";
     }
 
-    "Downloading latest enclave version from $($selectedPackage.Url)";
+    "Downloading latest enclave version $newEnclaveVersion from $($selectedPackage.Url)";
 
     $enclaveInstallerFile = Join-Path $env:TEMP "enclave-$newEnclaveVersion.msi";
     $enclaveInstallLogFile = Join-Path $env:TEMP "enclave-$newEnclaveVersion.install.log"

--- a/setup-unattended.ps1
+++ b/setup-unattended.ps1
@@ -1,0 +1,133 @@
+#
+# This script will install or up
+#
+#
+[CmdletBinding()]
+param (
+    [Parameter(HelpMessage = "The enclave enrolment key to use when enrolling")]
+    [string]
+    $EnrolmentKey
+)
+
+# Hide progress bars to speed up downloads
+$ProgressPreference = 'SilentlyContinue';
+$ErrorActionPreference = 'Stop';
+
+$manifestDoc = Invoke-WebRequest -Uri "https://install.enclave.io/manifest/windows/setup-unattended-msi.json" | ConvertFrom-Json;
+
+$latestGaRelease = $manifestDoc.ReleaseVersions | Where-Object ReleaseType -EQ "GA" | Select-Object -Last 1;
+
+$newEnclaveVersion = "$($latestGaRelease.MajorVersion).$($latestGaRelease.MinorVersion).$($latestGaRelease.BuildVersion).$($latestGaRelease.RevisionVersion)";
+
+$ErrorActionPreference = 'SilentlyContinue';
+
+$enclaveBinaryPath = "C:\Program Files\Enclave Networks\Enclave\Agent\bin\enclave.exe";
+$enclaveTrayPath = "C:\Program Files\Enclave Networks\Enclave\Agent\bin\enclave-tray.exe";
+
+$existingEnclaveVersion = $(get-command $enclaveBinaryPath);
+
+$existingEnclaveVersion = ($existingEnclaveVersion.Version).ToString();
+
+$ErrorActionPreference = 'Stop';
+
+if ($newEnclaveVersion -ne $existingEnclaveVersion)
+{
+    # We need to install.
+    # Get the architecture
+    $systemArch = [System.Environment]::GetEnvironmentVariable('PROCESSOR_ARCHITECTURE', 'Machine');
+    $enclaveArch = '';
+    $vcRedistUrl = '';
+
+    if ($systemArch -eq 'AMD64')
+    {
+        $enclaveArch = 'X64';
+        $vcRedistUrl = 'https://aka.ms/vs/17/release/vc_redist.x64.exe';
+    }
+    elseif ($systemArch -eq 'ARM64')
+    {
+        $enclaveArch = 'Arm64';
+        $vcRedistUrl = 'https://aka.ms/vs/17/release/vc_redist.arm64.exe';
+    }
+    elseif ($systemArch -eq 'X86')
+    {
+        $enclaveArch = 'X86';
+        $vcRedistUrl = 'https://aka.ms/vs/17/release/vc_redist.x86.exe';
+    }
+
+    if ($enclaveArch -eq '')
+    {
+        Write-Error "Unsupported architecture $systemArch";
+        return 1;
+    }
+
+    # Now grab the latest installer.        
+    $selectedPackage = $latestGaRelease.Packages | Where Architecture -EQ $enclaveArch;
+
+    if (!$existingEnclaveVersion)
+    {
+        "Installing VC++ Redistributable if needed";
+
+        $vcRedistInstallPath = Join-Path $env:TEMP "enclave_vcredist.exe";
+    
+        # No existing version; install latest VC++ (will quickly complete if it already exists)
+        Invoke-WebRequest -Uri $vcRedistUrl -OutFile $vcRedistInstallPath;
+
+        & $vcRedistInstallPath "/install" "/silent" "/norestart";
+    }
+
+    "Downloading latest enclave version from $($selectedPackage.Url)";
+
+    $enclaveInstallerFile = Join-Path $env:TEMP "enclave-$newEnclaveVersion.msi";
+    $enclaveInstallLogFile = Join-Path $env:TEMP "enclave-$newEnclaveVersion.install.log"
+
+    Invoke-WebRequest $selectedPackage.Url -OutFile $enclaveInstallerFile;
+
+    if ($existingEnclaveVersion)
+    {
+        "Closing any open instances of the enclave tray"
+        Get-Process "enclave-tray" -ErrorAction SilentlyContinue | Stop-Process -ErrorAction SilentlyContinue
+    }
+    
+    if ($existingEnclaveVersion -or !$EnrolmentKey)
+    {
+        # Don't need to re-enrol, we're already installed, or we don't have an enrolment key, so don't provide one to the installer.
+        "Installing enclave; writing install log to $enclaveInstallLogFile"
+        Start-Process msiexec "/i $enclaveInstallerFile /qn /l*v $enclaveInstallLogFile" -Wait
+    }
+    else 
+    {
+        # Not installed, provide the enrolment key.
+        "Installing enclave and enrolling; writing install log to $enclaveInstallLogFile"
+        Start-Process msiexec "/i $enclaveInstallerFile /qn /l*v $enclaveInstallLogFile ENROLMENT_KEY=$EnrolmentKey" -Wait
+
+        # Make sure we purge the enrolment key from the log file.
+        (Get-Content $enclaveInstallLogFile) -replace "$EnrolmentKey", '************' | Set-Content $enclaveInstallLogFile
+    }
+
+    # Give enclave 5s to get set up after the installer completes.
+    Start-Sleep -Seconds 5
+
+    if([Environment]::UserInteractive)
+    {
+        # Launch the tray.
+        & $enclaveTrayPath --tray
+    }
+}
+else 
+{
+    "Nothing to do; local installation is already at latest version $existingEnclaveVersion"
+}
+
+# Get installed enclave status.
+$enclaveStatus = $(& $enclaveBinaryPath status --json) | ConvertFrom-Json
+
+$subjectId = $enclaveStatus.Profile.Certificate.SubjectDistinguishedName;
+$virtualIp = $enclaveStatus.Profile.VirtualAddress;
+$installedVersion = $enclaveStatus.ProductVersion;
+
+return @{
+    SystemId = $subjectId;
+    VirtualIp = $virtualIp;
+    PreviousVersion = $existingEnclaveVersion
+    NewVersion = $installedVersion
+}


### PR DESCRIPTION
This powershell script will silently install or upgrade enclave on Windows using the MSI unattended installers, including:

- Grabbing latest vcredist on first install.
- Selecting the right architecture.
- Writing to a known msi log file, but also sanitising the log file after run to remove any references to the enrolment key.
- Outputting a powershell object at the end that contains some pertinent version and system information.

Example output
``` 
PS C:\Users\enclave-admin\Documents> ./unattended-install
Downloading latest enclave version from https://release.enclave.io/enclave-setup-unattended-x64-2023.8.22.1137.msi
Closing any open instances of the enclave tray
Installing enclave; writing install log to C:\Users\ENCLAV~1\AppData\Local\Temp\enclave-2023.8.22.1137.install.log

Name                           Value
----                           -----
NewVersion                     2023.8.22.1137
SystemId                       8L5ZD
PreviousVersion                2023.6.5.896
VirtualIp                      100.75.166.161
```