### PR TITLE
Avoid prompt for user confirmation in multi-user scenarios

### DIFF
--- a/setup-unattended.ps1
+++ b/setup-unattended.ps1
@@ -86,7 +86,7 @@ if ($newEnclaveVersion -ne $existingEnclaveVersion)
     if ($existingEnclaveVersion)
     {
         Write-Host "Closing any open instances of the enclave tray"
-        Get-Process "enclave-tray" -ErrorAction SilentlyContinue | Stop-Process -ErrorAction SilentlyContinue
+        Get-Process "enclave-tray" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
     }
     
     if ($existingEnclaveVersion -or !$EnrolmentKey)


### PR DESCRIPTION
By default, `Stop-Process` prompts for confirmation before stopping any process that is not owned by the current user.

Without the `-Force` flag, the PowerShell cmdlet `Stop-Process` will prompt for confirmation in multi-user scenarios where the EnclaveTray process is running multiple times, for different users where the script attempts to stop a process not owned by the current user.

```
PS C:\Users\marc> Get-Process "enclave-tray" -ErrorAction SilentlyContinue | Stop-Process

Confirm
Are you sure you want to perform the Stop-Process operation on the following item: enclave-tray(9548)?
[Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "Y"):
```

The `-Force` flag avoids prompting the user for confirmation, and so prevents the installation from hanging. [Source](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/stop-process?view=powershell-7.4#-force).